### PR TITLE
Update currency regex to match only ISO 4217 codes

### DIFF
--- a/currency/currency.go
+++ b/currency/currency.go
@@ -33,7 +33,7 @@ var symbols = map[string]string{
 	"$":   "USD",
 	"‎R$": "BRL",
 }
-var currencyRegexp = regexp.MustCompile(`(?i)(?:\s|^)(\d+)\s*(€|EUR|¥|円|JPY|\$|USD|‎R\$|BRL)(?:\s|,|\?|$)`)
+var currencyRegexp = regexp.MustCompile(`(?i)(?:\s|^)(\d+)\s*(EUR|JPY|USD|BRL)(?:\s|,|\?|$)`)
 
 func isLetter(s string) bool {
 	for _, r := range s {


### PR DESCRIPTION
I suggest to update currencyRegexp to match only ISO 4217 currencies codes to trigger Feldt, otherwise, it can be a bit too intrusive sometimes.